### PR TITLE
feat: updated default value for java_version due to resource update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | Application setting | `map(string)` | `{}` | no |
-| <a name="input_application_stack"></a> [application\_stack](#input\_application\_stack) | Application stack configuration, run `az webapp list-runtimes --os-type linux` to get the list of supported stacks | `map(string)` | <pre>{<br>  "java_server": "JAVA",<br>  "java_server_version": 11,<br>  "java_version": "java11"<br>}</pre> | no |
+| <a name="input_application_stack"></a> [application\_stack](#input\_application\_stack) | Application stack configuration, run `az webapp list-runtimes --os-type linux` to get the list of supported stacks | `map(string)` | <pre>{<br>  "java_server": "JAVA",<br>  "java_server_version": 11,<br>  "java_version": "11"<br>}</pre> | no |
 | <a name="input_application_type"></a> [application\_type](#input\_application\_type) | Application type (java, python, etc) | `string` | `"java"` | no |
 | <a name="input_enable_appinsights"></a> [enable\_appinsights](#input\_enable\_appinsights) | Enable application insights | `bool` | `true` | no |
 | <a name="input_appinsights_log_workspace_id"></a> [appinsights\_log\_workspace\_id](#input\_appinsights\_log\_workspace\_id) | Resource ID of Log Analytics workspace | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -111,7 +111,7 @@ variable "application_stack" {
   default = {
     java_server         = "JAVA"
     java_server_version = 11
-    java_version        = "java11"
+    java_version        = "11"
   }
   description = "Application stack configuration, run `az webapp list-runtimes --os-type linux` to get the list of supported stacks"
 }


### PR DESCRIPTION
Resource update:
`java_version` - Valid values are now 1.8, 11, and 17
https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.39.0
